### PR TITLE
Fixed threadFunc override ability.

### DIFF
--- a/include/module.h
+++ b/include/module.h
@@ -65,17 +65,17 @@ class Module {
   virtual void begin() const { }
 
   // thread worker function that gets executed as start() is called
-  static constexpr void threadFunc(void *params) { }
+  virtual void threadFunc() const { }
 
   // creates a new thread from the object running the threadFunc
   // @returns a handle to the new thread
-  TaskHandle_t start(void *params = nullptr) const {
+  TaskHandle_t start() const {
     std::lock_guard<std::mutex> lock(handle_lock_);
     xTaskCreate(
-      threadFunc,
+      [](void *obj) constexpr { static_cast<decltype(this)>(obj)->threadFunc(); }, // wrapper lambda
       name_,
       STACK_DEPTH,
-      params,
+      const_cast<Module*>(this), // removing const qualifyer as the API mandates void*
       PRIORITY,
       &task_handle_
     );


### PR DESCRIPTION
(In theory) this patch should fix up the problem with `threadFunc()` being a static function, hence derived classes not being able to override it.

The solution is the usage of a wrapper lmabda in the `start()` function, which casts the `void*` parameter (being the caller in this context) to `decltype<this>`, ensuring compatibility with its polymorphic type. As it's done, the `threadFunc()` is called with the now correctly casted parameter.

Sadly, this removes the option to provide `start()` with additional parameters. Until this causes any problems, the current imlpementation will remain.

An ugly part is the `const_cast`-ing of `this`, because the `const`-ness of the function provides `this` as a const pointer. As the thread (task) creation function takes `void*` as argument, this conflicts with the `-fpremissive` build flag. In theory removing the const qualifyer should not cause serious issues, as `threadFunc()` is also qualified `const`.