### PR TITLE
Removed the requirement for modules to be active to start a thread.

### DIFF
--- a/src/module/blinker_module.h
+++ b/src/module/blinker_module.h
@@ -34,7 +34,6 @@ class BlinkerModule : public Module<>
   void begin() const override
   {
     blinker.begin();
-    this->passState();
   }
 
   /// Turns the blinker on and off at the set intervals.

--- a/src/module/buzzer_module.h
+++ b/src/module/buzzer_module.h
@@ -35,7 +35,6 @@ class BuzzerModule : public Module<>
   void begin() const override
   {
     pinMode(c_buzzer_pin, OUTPUT);
-    this->passState();  
   }
 
   /// Sends power to the buzzer pin at the set regular intervals.

--- a/src/module/module.h
+++ b/src/module/module.h
@@ -111,7 +111,7 @@ class Module
   {
     std::lock_guard<std::mutex> lock(m_handle_lock);
     // only start new thread if none exists yet and the module is active
-    if (!m_task_handle && m_state == ACTIVE)
+    if (!m_task_handle)
     {
       xTaskCreate(
         [](void *obj) constexpr // wrapper lambda


### PR DESCRIPTION
From now on it's developer responsibility in threadFunc() to check for correct behaviour.