### PR TITLE
Upd-module-stdstring-name

### DIFF
--- a/src/module/basic_wire_disconnect.h
+++ b/src/module/basic_wire_disconnect.h
@@ -34,7 +34,7 @@ class WireDisconnect : public Module<>
 //===-- Instantiation specific functions ----------------------------------===//
 
  public:
-  explicit WireDisconnect(const char *const name,
+  explicit WireDisconnect(const std::string &name,
                           uint8_t wire_1, uint8_t wire_2, uint8_t wire_3,
                           const RGBLED &led_ref)
   : Module(name),

--- a/src/module/blinker_module.h
+++ b/src/module/blinker_module.h
@@ -25,9 +25,8 @@ class BlinkerModule : public Module<>
 {
 //===-- Instantiation specific functions and threading function -----------===//
  public:
-  explicit BlinkerModule(const char *const name, const uint8_t pin)
-  : Module(name),
-    blinker(pin)
+  explicit BlinkerModule(const std::string &name, const uint8_t pin)
+  : Module(name), blinker(pin)
   { }
   
   /// Sets up blinker pin and makes the module active.

--- a/src/module/buzzer_module.h
+++ b/src/module/buzzer_module.h
@@ -26,9 +26,8 @@ class BuzzerModule : public Module<>
 {
 //===-- Instantiation specific functions and threading function -----------===//
  public:
-  explicit BuzzerModule(const char *const name, const uint8_t pin)
-  : Module(name),
-    c_buzzer_pin(pin)
+  explicit BuzzerModule(const std::string &name, const uint8_t pin)
+  : Module(name), c_buzzer_pin(pin)
   { }
 
   /// Sets up buzzer pin and makes the module active.

--- a/src/module/keypad_module.h
+++ b/src/module/keypad_module.h
@@ -81,7 +81,7 @@ class Keypad : public Module<>
 
 //===-- Instantiation specific functions ----------------------------------===//
  public:
-  explicit Keypad(const char *const module_name,
+  explicit Keypad(const std::string &module_name,
                   std::initializer_list<uint8_t> col_pins,
                   std::initializer_list<uint8_t> row_pins,
                   std::array<std::array<char, COLS>, ROWS> &&char_set)

--- a/test/test_module_base.cpp
+++ b/test/test_module_base.cpp
@@ -4,7 +4,7 @@
 
 class EmptyModule : public PTS::Module<> {
  public:
-  EmptyModule(const char const *name) : Module(name) { }
+  EmptyModule(const std::string &name) : Module(name) { }
   void begin() const override { }
   void threadFunc() const override { }
 };


### PR DESCRIPTION
Updated the Module base class and its derived classes to use std::string for name storage. This makes the ecosystem easier to scale.